### PR TITLE
fix: respect iOS PWA status bar in headers

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -68,7 +68,9 @@ export default function RootLayout({
           />
         )}
         <NuqsAdapter>
-          <QueryProvider>{children}</QueryProvider>
+          <QueryProvider>
+            <div className="pt-[env(safe-area-inset-top)]">{children}</div>
+          </QueryProvider>
         </NuqsAdapter>
       </body>
     </html>

--- a/src/app/watch/[id]/[episode]/page.tsx
+++ b/src/app/watch/[id]/[episode]/page.tsx
@@ -433,7 +433,7 @@ export default function WatchPage({ params }: PageProps) {
       </div>
 
       {/* Header Breadcrumb */}
-      <header className="fixed top-0 left-0 right-0 z-50 py-3 md:py-4 px-4 md:px-6 bg-linear-to-b from-background/90 to-transparent">
+      <header className="fixed top-0 left-0 right-0 z-50 pt-[calc(env(safe-area-inset-top,0px)+0.75rem)] md:pt-[calc(env(safe-area-inset-top,0px)+1rem)] pb-3 md:pb-4 px-4 md:px-6 bg-linear-to-b from-background/90 to-transparent">
         <div className="flex justify-center">
           <nav className="flex items-center gap-1.5 md:gap-2 text-xs md:text-sm w-full max-w-[1300px]">
             <Link

--- a/src/components/blocks/navbar.tsx
+++ b/src/components/blocks/navbar.tsx
@@ -12,7 +12,7 @@ export function Navbar() {
   return (
     <>
       <CommandMenu />
-      <nav className="fixed top-0 left-0 right-0 z-50 bg-background/80 backdrop-blur-md border-b border-border">
+      <nav className="fixed top-0 left-0 right-0 z-50 bg-background/80 backdrop-blur-md border-b border-border pt-[env(safe-area-inset-top)]">
         <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
           <div className="flex h-14 items-center justify-between">
             <div className="flex items-center gap-8">


### PR DESCRIPTION
- Add safe-area-inset-top padding to navbar for iOS PWA status bar
- Add safe-area wrapper in layout.tsx to push all content below status bar
- Keep existing page padding (pt-14) unchanged